### PR TITLE
Use serialize-javascript instead of JSON.stringify to sanitize strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var serializeJavascript = require('serialize-javascript')
+
 module.exports = JSONGlobals
 
 function JSONGlobals(hash, value) {
@@ -13,8 +15,8 @@ function JSONGlobals(hash, value) {
         "}\n"
 
     Object.keys(hash).forEach(function (key) {
-        payload += "window.__JSON_GLOBALS_[" + JSON.stringify(key) +
-            "] = " + JSON.stringify(hash[key], null, "    ") + "\n"
+        payload += "window.__JSON_GLOBALS_[" + serializeJavascript(key) +
+            "] = " + serializeJavascript(hash[key]) + "\n"
     })
 
     return payload

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "global": "~2.0.1",
+    "global": "~4.3.0",
     "serialize-javascript": "^1.1.2"
   },
   "devDependencies": {
-    "tape": "~1.0.2"
+    "tape": "~4.4.0"
   },
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "global": "~2.0.1"
+    "global": "~2.0.1",
+    "serialize-javascript": "^1.1.2"
   },
   "devDependencies": {
     "tape": "~1.0.2"

--- a/test/index.js
+++ b/test/index.js
@@ -8,16 +8,23 @@ test("JSONGlobals is a function", function (assert) {
 })
 
 test("Can globalify stuff", function (assert) {
-    var html = JSONGlobals({ user: { name: "bob" } })
+    var html = JSONGlobals({
+        plain: { name: "bob" },
+        regex: /foo/,
+        malicious: '</script>'
+    })
 
     assert.equal(html,
         "if (!window.__JSON_GLOBALS_) {\n" +
         "    window.__JSON_GLOBALS_ = {}\n" +
         "}\n" +
-        "window.__JSON_GLOBALS_[\"user\"] = {\n" +
-        "    \"name\": \"bob\"\n" +
-        "}\n"
+
+        "window.__JSON_GLOBALS_[\"plain\"] = {\"name\":\"bob\"}\n" +
+        "window.__JSON_GLOBALS_[\"regex\"] = /foo/\n" +
+        "window.__JSON_GLOBALS_[\"malicious\"] = " +
+            "\"\\u003C\\u002Fscript\\u003E\"\n"
     )
 
     assert.end()
 })
+


### PR DESCRIPTION
This prevents potential malicious code execution when using JSONGlobals on the server.

``` javascript
var JSONGlobals = require("json-globals");
var url = require('url');

require('http').createServer(function (req, res) {
  res.writeHead(200, { 'content-type': 'text/html', 'x-xss-protection': 0 });
  res.end('<html><head><script>' +
    // Using unsanitized query:
    JSONGlobals({ data: url.parse(req.url,  true).query }) +
  '</script><body></body></html>');
}).listen(3000);
```

![screen shot 2016-02-11 at 11 43 14 am](https://cloud.githubusercontent.com/assets/1486609/12988304/ef3453b2-d0b4-11e5-838b-0c21c7ca2bb8.png)
