### PR TITLE
Remove globals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.9
   - 0.10
+  - 0.12
+  - 4
+  - 5
 script: node ./test/index.js

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 <!-- [![browser support][5]][6] -->
 
-Safely embed serialized javascript or JSON in a page as temporary global data
+Safely embed serialized javascript or JSON in a page as temporary global data.
+RegExp objects are properly serialized and HTML tags are sanitized.
 
 ## Example for the server
 
@@ -13,7 +14,11 @@ var JSONGlobals = require("safe-json-globals")
 
 function (req, res) {
     getUser(req, res, function (userRecord) {
-        var text = JSONGlobals({ user: userRecord })
+        var text = JSONGlobals({
+          user: userRecord,
+          potentialMaliciousContent: "</script><script>alert('hack')"
+        })
+
         var html = "" // whatever html
 
         html += "<script>" + text + "</script>"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 <!-- [![browser support][5]][6] -->
 
-Safely embed serialized javascript or JSON in a page as temporary global data.
-RegExp objects are properly serialized and HTML tags are sanitized.
+Safely embed serialized JSON in a page as temporary global data. HTML tags are sanitized.
 
 ## Example for the server
 
@@ -14,14 +13,14 @@ var JSONGlobals = require("safe-json-globals")
 
 function (req, res) {
     getUser(req, res, function (userRecord) {
-        var text = JSONGlobals({
+        var globalsMarkup = JSONGlobals({
           user: userRecord,
           potentialMaliciousContent: "</script><script>alert('hack')"
         })
 
         var html = "" // whatever html
 
-        html += "<script>" + text + "</script>"
+        html += globalsMarkup
 
         res.end(html)
     })

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# json-globals
+# safe-json-globals
 
 [![build status][1]][2] [![dependency status][3]][4]
 
 <!-- [![browser support][5]][6] -->
 
-Embed JSON in a page as temporary global data
+Safely embed serialized javascript or JSON in a page as temporary global data
 
 ## Example for the server
 
 ```js
-var JSONGlobals = require("json-globals")
+var JSONGlobals = require("safe-json-globals")
 
 function (req, res) {
     getUser(req, res, function (userRecord) {
@@ -26,24 +26,25 @@ function (req, res) {
 ## Example for the client
 
 ```js
-var JSONGlobals = require("json-globals/get")
+var JSONGlobals = require("safe-json-globals/get")
 
 var user = JSONGlobals("user")
 ```
 
 ## Installation
 
-`npm install json-globals`
+`npm install safe-json-globals`
 
 ## Contributors
 
  - Raynos
+ - lxe
 
 ## MIT Licenced
 
-  [1]: https://secure.travis-ci.org/Raynos/json-globals.png
-  [2]: https://travis-ci.org/Raynos/json-globals
-  [3]: https://david-dm.org/Raynos/json-globals.png
-  [4]: https://david-dm.org/Raynos/json-globals
-  [5]: https://ci.testling.com/Raynos/json-globals.png
-  [6]: https://ci.testling.com/Raynos/json-globals
+  [1]: https://secure.travis-ci.org/lxe/safe-json-globals.png
+  [2]: https://travis-ci.org/lxe/safe-json-globals
+  [3]: https://david-dm.org/lxe/safe-json-globals.png
+  [4]: https://david-dm.org/lxe/safe-json-globals
+  [5]: https://ci.testling.com/lxe/safe-json-globals.png
+  [6]: https://ci.testling.com/lxe/safe-json-globals

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,3 @@
+module.exports = {
+  get: require('./get.js');
+};

--- a/get.js
+++ b/get.js
@@ -1,12 +1,12 @@
-var document = require("global/document")
+var document = require("global/document");
 
-module.exports = getJSONGlobal
+module.exports = getJSONGlobal;
 
 var globals;
 function getJSONGlobal(key) {
     if (!globals) {
-      var jsonGlobalsElement = document.getElementById('json-globals')
-      globals = JSON.parse(jsonGlobalsElement.textContent)
+      var jsonGlobalsElement = document.getElementById('json-globals');
+      globals = JSON.parse(jsonGlobalsElement.textContent);
     }
     return globals[key];
 }

--- a/get.js
+++ b/get.js
@@ -1,8 +1,12 @@
-var window = require("global/window")
+var document = require("global/document")
 
 module.exports = getJSONGlobal
 
+var globals;
 function getJSONGlobal(key) {
-    var globals = window.__JSON_GLOBALS_ || {}
-    return globals[key]
+    if (!globals) {
+      var jsonGlobalsElement = document.getElementById('json-globals')
+      globals = JSON.parse(jsonGlobalsElement.textContent)
+    }
+    return globals[key];
 }

--- a/get.js
+++ b/get.js
@@ -1,5 +1,3 @@
-var document = require("global/document");
-
 module.exports = getJSONGlobal;
 
 var globals;

--- a/index.js
+++ b/index.js
@@ -9,15 +9,9 @@ function JSONGlobals(hash, value) {
         hash[key] = value
     }
 
-    var payload =
-        "if (!window.__JSON_GLOBALS_) {\n" +
-        "    window.__JSON_GLOBALS_ = {}\n" +
-        "}\n"
-
-    Object.keys(hash).forEach(function (key) {
-        payload += "window.__JSON_GLOBALS_[" + serializeJavascript(key) +
-            "] = " + serializeJavascript(hash[key]) + "\n"
-    })
+    var payload = '<script id="json-globals" type="application/json">';
+    payload += serializeJavascript(hash);
+    payload += '</script>';
 
     return payload
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",
   "repository": "git://github.com/lxe/safe-json-globals.git",
-  "main": "index",
+  "main": "index.js",
+  "browser": "browser.js",
   "homepage": "https://github.com/lxe/safe-json-globals",
   "contributors": [
     {
@@ -21,7 +22,6 @@
     "email": "lxe@lxe.co"
   },
   "dependencies": {
-    "global": "~4.3.0",
     "serialize-javascript": "^1.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "email": "lxe@lxe.co"
   },
   "dependencies": {
-    "global": "~2.0.1"
+    "global": "~4.3.0",
+    "serialize-javascript": "^1.1.2"
   },
   "devDependencies": {
-    "tape": "~1.0.2"
+    "tape": "~4.4.0"
   },
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-json-globals",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Safely embed serialized javascript or JSON in a page as temporary global data",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,24 @@
 {
-  "name": "json-globals",
-  "version": "0.2.1",
-  "description": "Embed JSON in a page as temporary global data",
+  "name": "safe-json-globals",
+  "version": "1.0.0",
+  "description": "Safely embed serialized javascript or JSON in a page as temporary global data",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",
-  "repository": "git://github.com/Raynos/json-globals.git",
+  "repository": "git://github.com/lxe/safe-json-globals.git",
   "main": "index",
-  "homepage": "https://github.com/Raynos/json-globals",
+  "homepage": "https://github.com/lxe/safe-json-globals",
   "contributors": [
     {
       "name": "Raynos"
+    },
+    {
+      "name": "Aleksey Smolenchuk",
+      "email": "lxe@lxe.co"
     }
   ],
   "bugs": {
-    "url": "https://github.com/Raynos/json-globals/issues",
-    "email": "raynos2@gmail.com"
+    "url": "https://github.com/lxe/safe-json-globals/issues",
+    "email": "lxe@lxe.co"
   },
   "dependencies": {
     "global": "~2.0.1"
@@ -25,7 +29,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "http://github.com/Raynos/json-globals/raw/master/LICENSE"
+      "url": "http://github.com/lxe/safe-json-globals/raw/master/LICENSE"
     }
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-json-globals",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Safely embed serialized javascript or JSON in a page as temporary global data",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-json-globals",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Safely embed serialized javascript or JSON in a page as temporary global data",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-json-globals",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Safely embed serialized javascript or JSON in a page as temporary global data",
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",

--- a/test/index.js
+++ b/test/index.js
@@ -15,16 +15,10 @@ test("Can globalify stuff", function (assert) {
     })
 
     assert.equal(html,
-        "if (!window.__JSON_GLOBALS_) {\n" +
-        "    window.__JSON_GLOBALS_ = {}\n" +
-        "}\n" +
-
-        "window.__JSON_GLOBALS_[\"plain\"] = {\"name\":\"bob\"}\n" +
-        "window.__JSON_GLOBALS_[\"regex\"] = /foo/\n" +
-        "window.__JSON_GLOBALS_[\"malicious\"] = " +
-            "\"\\u003C\\u002Fscript\\u003E\"\n"
-    )
+      '<script id="json-globals" type="application/json">' +
+      '{"plain":{"name":"bob"},"regex":/foo/,"malicious":"\\u003C\\u002Fscript\\u003E"}' +
+      '</script>'
+    );
 
     assert.end()
 })
-


### PR DESCRIPTION
This removes the `globals` library which dumps a bunch of shims for server-only DOM support. See https://github.com/sindresorhus/globals/issues/82
